### PR TITLE
fix: Update @Value annotations and properties-maven-plugin to correctly reference property keys

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
                 <version>1.2.0</version>
                 <executions>
                     <execution>
-                        <phase>package</phase>
+                        <phase>initialize</phase>
                         <goals>
                             <goal>write-project-properties</goal>
                         </goals>

--- a/src/main/java/tutorial/buildon/aws/o11y/HelloAppController.java
+++ b/src/main/java/tutorial/buildon/aws/o11y/HelloAppController.java
@@ -26,10 +26,10 @@ public class HelloAppController {
     private static final Logger log =
         LoggerFactory.getLogger(HelloAppController.class);
 
-    @Value("otel.traces.api.version")
+    @Value("${otel.traces.api.version}")
     private String tracesApiVersion;
 
-    @Value("otel.metrics.api.version")
+    @Value("${otel.metrics.api.version}")
     private String metricsApiVersion;
 
     private final Tracer tracer =


### PR DESCRIPTION
*Issue #, if available:*

1. What Changed?
  * Updated the @Value annotations in controller to correctly reference properties, now using {} i.e @Value("${property.key}")
  * Updated the properties-maven-plugin execution phase from package -> initialize to ensure property files are included in the final JAR
2. What is the reason for change?
  * The original code had @Value annotations without curly brackets as a result spring does not resolve properties, and the application did not throw errors even though properties were not being loaded
  * The previous configuration of properties-maven-plugin did not copy property files in the generated JAR
3. Is there anything to watch out for anything particularly remarkable?
  * This fix addresses the issue of missing properties and inconsistent property resolution. There is nothing remarkable to note beyond standard fixes


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
